### PR TITLE
Use UTC datetimes internally

### DIFF
--- a/custom_components/gpslogger/__init__.py
+++ b/custom_components/gpslogger/__init__.py
@@ -77,6 +77,8 @@ async def async_setup(hass: HomeAssistant, _: ConfigType) -> bool:
     async def device_work_around(_: Event) -> None:
         """Work around for device tracker component deleting devices.
 
+        Applies to HA versions prior to 2024.5:
+
         The device tracker component level code, at startup, deletes devices that are
         associated only with device_tracker entities. Not only that, it will delete
         those device_tracker entities from the entity registry as well. So, when HA

--- a/custom_components/gpslogger/manifest.json
+++ b/custom_components/gpslogger/manifest.json
@@ -4,8 +4,8 @@
   "codeowners": ["@pnbruckner"],
   "config_flow": true,
   "dependencies": ["webhook"],
-  "documentation": "https://github.com/pnbruckner/ha-gpslogger/blob/1.0.2/README.md",
+  "documentation": "https://github.com/pnbruckner/ha-gpslogger/blob/1.0.3b0/README.md",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/pnbruckner/ha-gpslogger/issues",
-  "version": "1.0.2"
+  "version": "1.0.3b0"
 }


### PR DESCRIPTION
Python datetime object comparisons and math don't work as expected when the objects are aware and have the same tzinfo attribute. Basically, the fold attribute is ignored in this case, which can lead to wrong results.

Avoid this problem by using aware times in UTC internally. Only use local time zone for user visible attributes.